### PR TITLE
Fix spelling of JSI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Calling "make" will build
 Contributors:
 ----------------
 
-Original version form Joseph Stephan Institute (http://lemmatise.ijs.si/)
+Original version from Jožef Stefan Institute (http://lemmatise.ijs.si/)
 
 * Jernej Virag
 * Domen Grabec


### PR DESCRIPTION
Official English spelling of the name of the institute is "Jozef Stefan
Institute". See e.g. https://www.ijs.si/ijsw/JSI or copyright footer of
http://lemmatise.ijs.si/. This is the name that's used for all
international publications as far as I know.

I've never seen the name spelled "Joseph Stephan".